### PR TITLE
Formatting, clippy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+target/
+Cargo.lock
+node_modules
+.DS_Store

--- a/aibe/src/bf_ibe.rs
+++ b/aibe/src/bf_ibe.rs
@@ -1,11 +1,11 @@
 use crate::errors::IbeError;
-use rand::Rng;
-use bn::{G1, G2, Gt, Fr as Scalar, Group, pairing};
-use bn::arith::U256;
-use borsh::maybestd::collections::HashMap;
 use crate::traits::IdentityBasedEncryption;
-use crate::traits::ToBytes;
-use crate::utils::{u64_to_scalar, hash_to_g2, baby_step_giant_step};
+
+use crate::utils::{baby_step_giant_step, hash_to_g2};
+
+use bn::{pairing, Fr as Scalar, Group, Gt, G1, G2};
+
+use rand::Rng;
 
 pub type CipherText = (G1, Gt);
 pub type PlainData = Scalar;
@@ -17,81 +17,90 @@ pub type IdSecretKey = G2;
 ///
 ///
 /// # Examples
-/// 
+///
 /// ```
 /// use aibe::traits::{IdentityBasedEncryption};
 /// use aibe::bf_ibe::{BFIbe};
 /// use rand::Rng;
-/// let mut rng = rand::thread_rng(); 
-/// let mut ibe = BFIbe::new(rng); 
+/// let mut rng = rand::thread_rng();
+/// let mut ibe = BFIbe::new(rng);
 /// ```
 #[derive(Debug)]
 pub struct BFIbe<R> {
-	rng: R,
+    rng: R,
 }
 
 impl<R> BFIbe<R>
-where R: Rng {
-
-
-	pub	fn new(rng: R) -> Self {
-		Self {
-			rng,
-		}
-	}
-
-    pub fn encrypt_internal(&mut self, msg: &PlainData, id: &str, mpk: &MasterPublicKey) -> (CipherText, G2, Scalar) {
-		
-		let hash_id = hash_to_g2(id.as_bytes());
-        let r = Scalar::random(&mut self.rng);
-		let c1 = G1::one() * r;
-		let c2_part1 = pairing(G1::one(), G2::one()).pow(*msg);
-		let c2_part2 = pairing(*mpk, hash_id).pow(r);
-		let c2 = c2_part1 * c2_part2;
-
-		((c1, c2), hash_id, r)
+where
+    R: Rng,
+{
+    pub fn new(rng: R) -> Self {
+        Self { rng }
     }
 
-    pub fn encrypt_correlated_internal(&mut self, msg: &PlainData, ids: (&str, &str), mpks: (&MasterPublicKey, &MasterPublicKey)) -> ((CipherText, CipherText), (G2, G2), Scalar) {
-		
+    pub fn encrypt_internal(
+        &mut self,
+        msg: &PlainData,
+        id: &str,
+        mpk: &MasterPublicKey,
+    ) -> (CipherText, G2, Scalar) {
+        let hash_id = hash_to_g2(id.as_bytes());
         let r = Scalar::random(&mut self.rng);
-		let c1 = G1::one() * r;
+        let c1 = G1::one() * r;
+        let c2_part1 = pairing(G1::one(), G2::one()).pow(*msg);
+        let c2_part2 = pairing(*mpk, hash_id).pow(r);
+        let c2 = c2_part1 * c2_part2;
+
+        ((c1, c2), hash_id, r)
+    }
+
+    pub fn encrypt_correlated_internal(
+        &mut self,
+        msg: &PlainData,
+        ids: (&str, &str),
+        mpks: (&MasterPublicKey, &MasterPublicKey),
+    ) -> ((CipherText, CipherText), (G2, G2), Scalar) {
+        let r = Scalar::random(&mut self.rng);
+        let c1 = G1::one() * r;
         let c2_part1 = pairing(G1::one(), G2::one() * *msg);
 
-		let hash_id1 = hash_to_g2(ids.0.as_bytes());
-		let c2_part2 = pairing(*mpks.0, hash_id1 * r);
-		let cipher_1 = (c1, c2_part1 * c2_part2);
+        let hash_id1 = hash_to_g2(ids.0.as_bytes());
+        let c2_part2 = pairing(*mpks.0, hash_id1 * r);
+        let cipher_1 = (c1, c2_part1 * c2_part2);
 
         let hash_id2 = hash_to_g2(ids.1.as_bytes());
         let c2_part2 = pairing(*mpks.1, hash_id2 * r);
         let cipher_2 = (c1, c2_part1 * c2_part2);
 
-		((cipher_1, cipher_2), (hash_id1, hash_id2), r)
+        ((cipher_1, cipher_2), (hash_id1, hash_id2), r)
     }
-
 }
 
 impl<R> IdentityBasedEncryption for BFIbe<R>
-where R: Rng {
+where
+    R: Rng,
+{
     type CipherText = (G1, Gt);
     type PlainData = Scalar;
-	type MasterSecretKey = Scalar;
-	type MasterPublicKey = G1;
-	type IdSecretKey = G2;
-
+    type MasterSecretKey = Scalar;
+    type MasterPublicKey = G1;
+    type IdSecretKey = G2;
 
     /// Generate a pair of master secret key and master public key.
     ///
     /// # Examples
     ///
-    /// ```ignore
-    /// let mut rng = rand::thread_rng(); 
-    /// let mut ibe = BFIbe::new(rng); 
+    /// ```
+    /// # use aibe::traits::IdentityBasedEncryption;
+    /// # use aibe::bf_ibe::BFIbe;
+    /// # use rand::Rng;
+    /// let mut rng = rand::thread_rng();
+    /// let mut ibe = BFIbe::new(rng);
     /// let (msk, mpk) = ibe.generate_key();
     /// ```
     fn generate_key(&mut self) -> (Self::MasterSecretKey, Self::MasterPublicKey) {
-        let msk = Scalar::random(&mut self.rng);        
-		let mpk = G1::one() * msk; 
+        let msk = Scalar::random(&mut self.rng);
+        let mpk = G1::one() * msk;
         (msk, mpk)
     }
 
@@ -99,30 +108,48 @@ where R: Rng {
     ///
     /// # Examples
     ///
-    /// ```ignore
-    /// let mut rng = rand::thread_rng(); 
-    /// let mut ibe = BFIbe::new(rng); 
-    /// let (_, mpk) = ibe.generate_key();
-    /// let cipher = ibe.encrypt("alice", u64_to_scalar(35), mpk);
     /// ```
-    fn encrypt(&mut self, msg: &Self::PlainData, id: &str, mpk: &Self::MasterPublicKey) -> Self::CipherText {
+    /// # use aibe::traits::IdentityBasedEncryption;
+    /// # use aibe::bf_ibe::BFIbe;
+    /// # use rand::Rng;
+    /// # use aibe::utils::u64_to_scalar;
+    /// let mut rng = rand::thread_rng();
+    /// let mut ibe = BFIbe::new(rng);
+    /// let (_, mpk) = ibe.generate_key();
+    /// let cipher = ibe.encrypt(&u64_to_scalar(35), "alice", &mpk);
+    /// ```
+    fn encrypt(
+        &mut self,
+        msg: &Self::PlainData,
+        id: &str,
+        mpk: &Self::MasterPublicKey,
+    ) -> Self::CipherText {
         let (c, _, _) = self.encrypt_internal(msg, id, mpk);
-		
-	    c	
+
+        c
     }
 
     /// Correlated encryption of the same message, such that two ciphertexts have the same 1st component (randomness).
     ///
     /// # Examples
     ///
-    /// ```ignore
-    /// let mut rng = rand::thread_rng(); 
-    /// let mut ibe = BFIbe::new(rng); 
+    /// ```
+    /// # use aibe::traits::IdentityBasedEncryption;
+    /// # use aibe::bf_ibe::BFIbe;
+    /// # use rand::Rng;
+    /// # use aibe::utils::u64_to_scalar;
+    /// let mut rng = rand::thread_rng();
+    /// let mut ibe = BFIbe::new(rng);
     /// let (_, mpk1) = ibe.generate_key();
     /// let (_, mpk2) = ibe.generate_key();
-    /// let (cipher1, cipher2) = ibe.encrypt_correlated(u64_to_scalar(35), ("alice", "bob"), (&mpk1, &mpk2));
+    /// let (cipher1, cipher2) = ibe.encrypt_correlated(&u64_to_scalar(35), ("alice", "bob"), (&mpk1, &mpk2));
     /// ```
-    fn encrypt_correlated(&mut self, msg: &Self::PlainData, ids: (&str, &str), mpks: (&Self::MasterPublicKey, &Self::MasterPublicKey)) -> (Self::CipherText, Self::CipherText) {
+    fn encrypt_correlated(
+        &mut self,
+        msg: &Self::PlainData,
+        ids: (&str, &str),
+        mpks: (&Self::MasterPublicKey, &Self::MasterPublicKey),
+    ) -> (Self::CipherText, Self::CipherText) {
         let (c, _, _) = self.encrypt_correlated_internal(msg, ids, mpks);
 
         c
@@ -132,34 +159,52 @@ where R: Rng {
     ///
     /// # Examples
     ///
-    /// ```ignore
-    /// let mut rng = rand::thread_rng(); 
-    /// let mut ibe = BFIbe::new(rng); 
+    /// ```
+    /// # use aibe::traits::IdentityBasedEncryption;
+    /// # use aibe::bf_ibe::BFIbe;
+    /// # use rand::Rng;
+    /// let mut rng = rand::thread_rng();
+    /// let mut ibe = BFIbe::new(rng);
     /// let (msk, _) = ibe.generate_key();
-    /// let sk = ibe.extract("alice", msk);
+    /// let sk = ibe.extract("alice", &msk);
     /// ```
     fn extract(&mut self, id: &str, msk: &Self::MasterSecretKey) -> Self::IdSecretKey {
-		let hash_id = hash_to_g2(id.as_bytes());
-		hash_id * *msk
+        let hash_id = hash_to_g2(id.as_bytes());
+        hash_id * *msk
     }
 
     /// Decryption.
     ///
     /// # Examples
     ///
-    /// ```ignore
+    /// ```
+    /// # use aibe::traits::IdentityBasedEncryption;
+    /// # use aibe::bf_ibe::BFIbe;
+    /// # use rand::Rng;
+    /// # use aibe::utils::u64_to_scalar;
+    /// # let mut rng = rand::thread_rng(); 
+    /// # let mut ibe = BFIbe::new(rng); 
+    /// # let (msk, mpk) = ibe.generate_key();
+    /// # let cipher = ibe.encrypt(&u64_to_scalar(35), "alice", &mpk);
+    /// # let sk = ibe.extract("alice", &msk);
     /// // Following the examples of `encrypt` and `extract`
-    /// let result = ibe.decrypt("alice", &cipher, &sk, 100); 
+    /// let result = ibe.decrypt(&cipher, "alice", &sk, 100);
+    /// # result.unwrap();
     /// ```
 
-    fn decrypt(&mut self, cipher: &Self::CipherText, id: &str, sk: &Self::IdSecretKey, bound: u64) -> Result<Self::PlainData, IbeError> {
-		let (c1, c2) = cipher;
-		let result = pairing(*c1, *sk).inverse().ok_or(IbeError::GtInverseError)?;
-		let result = *c2 * result;
+    fn decrypt(
+        &mut self,
+        cipher: &Self::CipherText,
+        _id: &str,
+        sk: &Self::IdSecretKey,
+        bound: u64,
+    ) -> Result<Self::PlainData, IbeError> {
+        let (c1, c2) = cipher;
+        let result = pairing(*c1, *sk)
+            .inverse()
+            .ok_or(IbeError::GtInverseError)?;
+        let result = *c2 * result;
 
         baby_step_giant_step(result, pairing(G1::one(), G2::one()), bound)
     }
-
 }
-
-

--- a/aibe/src/bin/burn_example.rs
+++ b/aibe/src/bin/burn_example.rs
@@ -1,18 +1,16 @@
-
-use aibe::traits::{IdentityBasedEncryption};
-use aibe::bf_ibe::{BFIbe};
-use aibe::utils::{u64_to_scalar, hash_to_g2};
-use aibe::zk::burn::{BurnStatement, BurnWitness, BurnProver, BurnVerifier};
-use rand::Rng;
+use aibe::bf_ibe::BFIbe;
+use aibe::traits::IdentityBasedEncryption;
+use aibe::utils::{hash_to_g2, u64_to_scalar};
+use aibe::zk::burn::{BurnProver, BurnStatement, BurnWitness};
 use borsh::ser::BorshSerialize;
+use rand::Rng;
 
 extern crate base64;
-
 
 fn main() {
     use std::time::Instant;
 
-    let mut rng = rand::thread_rng(); 
+    let mut rng = rand::thread_rng();
     let bound: u64 = 100;
     let plain = u64_to_scalar(rng.gen_range(0..bound));
 
@@ -36,13 +34,12 @@ fn main() {
     println!("[IBE encrypt]: {:.2?}", elapsed);
 
     let now = Instant::now();
-    let result = ibe.decrypt(&cipher, "zico", &sk, bound); 
+    let result = ibe.decrypt(&cipher, "zico", &sk, bound);
     let elapsed = now.elapsed();
     println!("[IBE Decrypt]: {:.2?}", elapsed);
 
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), plain);
-
 
     let statement = BurnStatement {
         y: mpk,
@@ -59,12 +56,15 @@ fn main() {
     let mut prover = BurnProver::new(rng.clone());
     let proof = prover.generate_proof(statement.clone(), witness);
 
-    println!("Burn proof:\n{}", base64::encode(proof.try_to_vec().unwrap()));
-    println!("Burn statement:\n{}", base64::encode(statement.try_to_vec().unwrap()));
+    println!(
+        "Burn proof:\n{}",
+        base64::encode(proof.try_to_vec().unwrap())
+    );
+    println!(
+        "Burn statement:\n{}",
+        base64::encode(statement.try_to_vec().unwrap())
+    );
 
     //let result = BurnVerifier::verify_proof(statement, proof);
     //assert!(result.is_ok());
 }
-
-
-

--- a/aibe/src/bin/transfer_example.rs
+++ b/aibe/src/bin/transfer_example.rs
@@ -1,19 +1,18 @@
-
-use aibe::traits::{IdentityBasedEncryption};
-use aibe::bf_ibe::{BFIbe};
-use aibe::utils::{u64_to_scalar, hash_to_g2, pedersen_commitment};
-use aibe::zk::transfer::{TransferStatement, TransferWitness, TransferProver, TransferVerifier};
-use rand::Rng;
-use bn::{G1, Group};
+use aibe::bf_ibe::BFIbe;
+use aibe::traits::IdentityBasedEncryption;
+use aibe::utils::{pedersen_commitment, u64_to_scalar};
+use aibe::zk::transfer::{TransferProver, TransferStatement, TransferWitness};
+use bn::{Group, G1};
 use borsh::ser::BorshSerialize;
+
 
 extern crate base64;
 
 fn main() {
     use std::time::Instant;
 
-    let mut rng = rand::thread_rng(); 
-    let bound: u64 = 100;
+    let mut rng = rand::thread_rng();
+    let _bound: u64 = 100;
     // Balance
     let b = u64_to_scalar(60);
     // Transfer amount
@@ -25,7 +24,7 @@ fn main() {
 
     let now = Instant::now();
     let (msk1, mpk1) = ibe.generate_key();
-    let (msk2, mpk2) = ibe.generate_key();
+    let (_msk2, mpk2) = ibe.generate_key();
     let elapsed = now.elapsed();
     println!("[IBE key gen]: {:.2?}", elapsed);
 
@@ -38,15 +37,16 @@ fn main() {
     // Encryption of balance for key 1
     let c_balance = ibe.encrypt(&b, "zico1", &mpk1);
     // Encryption of transfer amount for key 1 and key 2
-    let ((c_transfer, c_transfer_bar), (h_id, h_id_bar), r) = ibe.encrypt_correlated_internal(&b_star, ("zico1", "zico2"), (&mpk1, &mpk2));
+    let ((c_transfer, c_transfer_bar), (h_id, h_id_bar), r) =
+        ibe.encrypt_correlated_internal(&b_star, ("zico1", "zico2"), (&mpk1, &mpk2));
     let elapsed = now.elapsed();
     println!("[IBE encrypt]: {:.2?}", elapsed);
 
     let h1 = G1::random(&mut rng);
 
     let now = Instant::now();
-    let (r_star, c_b_star) = pedersen_commitment(b_star, h1, &mut rng); 
-    let (r_prime, c_b_prime) = pedersen_commitment(b_prime, h1, &mut rng); 
+    let (r_star, c_b_star) = pedersen_commitment(b_star, h1, &mut rng);
+    let (r_prime, c_b_prime) = pedersen_commitment(b_prime, h1, &mut rng);
     let elapsed = now.elapsed();
     println!("[Pedersen commitment]: {:.2?}", elapsed);
 
@@ -77,12 +77,15 @@ fn main() {
     let mut prover = TransferProver::new(rng.clone());
     let proof = prover.generate_proof(statement.clone(), witness);
 
-    println!("Transfer proof:\n{}", base64::encode(proof.try_to_vec().unwrap()));
-    println!("Transfer statement:\n{}", base64::encode(statement.try_to_vec().unwrap()));
+    println!(
+        "Transfer proof:\n{}",
+        base64::encode(proof.try_to_vec().unwrap())
+    );
+    println!(
+        "Transfer statement:\n{}",
+        base64::encode(statement.try_to_vec().unwrap())
+    );
 
     //let result = TransferVerifier::verify_proof(statement, proof);
     //assert!(result.is_ok());
 }
-
-
-

--- a/aibe/src/traits.rs
+++ b/aibe/src/traits.rs
@@ -1,40 +1,56 @@
 use crate::errors::IbeError;
-use bn::{G1, G2, Gt};
-use borsh::{BorshSerialize};
+use bn::{Gt, G1, G2};
 use borsh::maybestd::vec::Vec;
+use borsh::BorshSerialize;
 
 pub trait IdentityBasedEncryption {
     type CipherText;
     type PlainData;
-	type MasterSecretKey;
-	type MasterPublicKey;
-	type IdSecretKey;
+    type MasterSecretKey;
+    type MasterPublicKey;
+    type IdSecretKey;
 
-	fn generate_key(&mut self) -> (Self::MasterSecretKey, Self::MasterPublicKey);
-    fn encrypt(&mut self, msg: &Self::PlainData, id: &str, mpk: &Self::MasterPublicKey) -> Self::CipherText;
-    fn encrypt_correlated(&mut self, msg: &Self::PlainData, ids: (&str, &str), mpks: (&Self::MasterPublicKey, &Self::MasterPublicKey)) -> (Self::CipherText, Self::CipherText);
+    fn generate_key(&mut self) -> (Self::MasterSecretKey, Self::MasterPublicKey);
+    fn encrypt(
+        &mut self,
+        msg: &Self::PlainData,
+        id: &str,
+        mpk: &Self::MasterPublicKey,
+    ) -> Self::CipherText;
+    fn encrypt_correlated(
+        &mut self,
+        msg: &Self::PlainData,
+        ids: (&str, &str),
+        mpks: (&Self::MasterPublicKey, &Self::MasterPublicKey),
+    ) -> (Self::CipherText, Self::CipherText);
     fn extract(&mut self, id: &str, msk: &Self::MasterSecretKey) -> Self::IdSecretKey;
-    fn decrypt(&mut self, cipher: &Self::CipherText, id: &str, sk: &Self::IdSecretKey, bound: u64) -> Result<Self::PlainData, IbeError>;
+    fn decrypt(
+        &mut self,
+        cipher: &Self::CipherText,
+        id: &str,
+        sk: &Self::IdSecretKey,
+        bound: u64,
+    ) -> Result<Self::PlainData, IbeError>;
 }
 
 pub trait ToBytes {
-	fn to_bytes(&self) -> Vec<u8>;
+    fn to_bytes(&self) -> Vec<u8>;
 }
 
 impl ToBytes for Gt {
-	fn to_bytes(&self) -> Vec<u8> {
+    fn to_bytes(&self) -> Vec<u8> {
         self.try_to_vec().unwrap()
     }
 }
 
 impl ToBytes for G1 {
-	fn to_bytes(&self) -> Vec<u8> {
+    fn to_bytes(&self) -> Vec<u8> {
         self.try_to_vec().unwrap()
     }
 }
 
 impl ToBytes for G2 {
-	fn to_bytes(&self) -> Vec<u8> {
+    fn to_bytes(&self) -> Vec<u8> {
         self.try_to_vec().unwrap()
     }
 }

--- a/aibe/src/utils.rs
+++ b/aibe/src/utils.rs
@@ -1,13 +1,12 @@
 use crate::errors::IbeError;
-use rand::Rng;
-use bn::{G1, G2, Gt, Fr as Scalar, Group, pairing};
-use bn::arith::U256;
-use sha2::Digest;
-use borsh::maybestd::collections::HashMap;
-use crate::traits::IdentityBasedEncryption;
-use crate::traits::ToBytes;
-use libm::sqrt;
 
+use crate::traits::ToBytes;
+use bn::arith::U256;
+use bn::{Fr as Scalar, Group, Gt, G1, G2};
+use borsh::maybestd::collections::HashMap;
+use libm::sqrt;
+use rand::Rng;
+use sha2::Digest;
 
 pub fn hash_to_scalar(msg: &[u8]) -> Scalar {
     let hash = sha2::Sha256::digest(msg);
@@ -15,7 +14,7 @@ pub fn hash_to_scalar(msg: &[u8]) -> Scalar {
 }
 
 pub fn hash_to_g2(msg: &[u8]) -> G2 {
-    G2::one() * hash_to_scalar(msg) 
+    G2::one() * hash_to_scalar(msg)
 }
 
 pub fn u64_to_scalar(x: u64) -> Scalar {
@@ -33,14 +32,14 @@ pub fn baby_step_giant_step(h: Gt, g: Gt, bound: u64) -> Result<Scalar, IbeError
     while i <= m {
         table.insert(x.to_bytes(), i);
         x = x * g;
-		i = i + 1;
+        i += 1;
     }
 
     // search for solution
-	let z = g.pow(-u64_to_scalar(m));
+    let z = g.pow(-u64_to_scalar(m));
     //z.inverse();
     x = h;
-	i = 0;
+    i = 0;
     while i <= m {
         // positive solution
         match table.get(&x.to_bytes()) {
@@ -54,21 +53,21 @@ pub fn baby_step_giant_step(h: Gt, g: Gt, bound: u64) -> Result<Scalar, IbeError
         }
         // negative solution
         //match table.get(&x_neg.tostring()) {
-            //Some(value) => {
-                //let mut temp = BigNum::modmul(&i, &m, &CURVE_ORDER);
-                //temp = BigNum::modadd(&value, &temp, &CURVE_ORDER);
-                //temp = BigNum::modneg(&temp, &CURVE_ORDER);
-                //let temp = BigInt::from_str_radix(&temp.tostring(), 16).unwrap() - (&*MODULUS);
-                //return Some(temp);
-            //}
-            //None => {
-                //x_neg.mul(&z);
-                //x_neg.reduce();
-            //}
+        //Some(value) => {
+        //let mut temp = BigNum::modmul(&i, &m, &CURVE_ORDER);
+        //temp = BigNum::modadd(&value, &temp, &CURVE_ORDER);
+        //temp = BigNum::modneg(&temp, &CURVE_ORDER);
+        //let temp = BigInt::from_str_radix(&temp.tostring(), 16).unwrap() - (&*MODULUS);
+        //return Some(temp);
         //}
-        i = i + 1
+        //None => {
+        //x_neg.mul(&z);
+        //x_neg.reduce();
+        //}
+        //}
+        i += 1
     }
-	Err(IbeError::OutOfBoundError)
+    Err(IbeError::OutOfBoundError)
 }
 
 pub fn pedersen_commitment<R: Rng>(m: Scalar, h1: G1, rng: &mut R) -> (Scalar, G1) {

--- a/aibe/src/zk/transfer.rs
+++ b/aibe/src/zk/transfer.rs
@@ -1,17 +1,17 @@
-use borsh::{BorshDeserialize, BorshSerialize};
-use bn::{Fr as Scalar, G1, G2, Gt, pairing, Group};
 use crate::errors::ZkError;
 use crate::traits::ToBytes;
-use crate::utils::{hash_to_scalar};
-use rand::Rng;
-use core::ops::Neg;
+use crate::utils::hash_to_scalar;
+use bn::{pairing, Fr as Scalar, Group, Gt, G1, G2};
 use borsh::maybestd::vec::Vec;
+use borsh::{BorshDeserialize, BorshSerialize};
+use core::ops::Neg;
+use rand::Rng;
 
 #[derive(Eq, PartialEq, BorshDeserialize, BorshSerialize, Clone)]
 pub struct TransferStatement {
     pub h1: G1,
     pub y: G1,
-    pub y_bar: G1, 
+    pub y_bar: G1,
     pub c1: G1,
     pub c2: Gt,
     pub c2_bar: Gt,
@@ -32,7 +32,6 @@ pub struct TransferWitness {
     pub h_id: G2,
     pub h_id_bar: G2,
     pub sk_id: G2,
-
 }
 
 #[derive(Eq, PartialEq, BorshDeserialize, BorshSerialize, Clone, Debug)]
@@ -52,20 +51,23 @@ pub struct TransferProof {
 }
 
 pub struct TransferProver<R> {
-    rng: R
+    rng: R,
 }
 
-
-impl<R> TransferProver<R> 
-where R: Rng {
+impl<R> TransferProver<R>
+where
+    R: Rng,
+{
     pub fn new(rng: R) -> Self {
-        Self {
-            rng
-        }
+        Self { rng }
     }
 
-    pub fn generate_proof(&mut self, statement: TransferStatement, witness: TransferWitness) -> TransferProof {
-        let mr = Scalar::random(&mut self.rng); 
+    pub fn generate_proof(
+        &mut self,
+        statement: TransferStatement,
+        witness: TransferWitness,
+    ) -> TransferProof {
+        let mr = Scalar::random(&mut self.rng);
         let ms = Scalar::random(&mut self.rng);
         let mr_star = Scalar::random(&mut self.rng);
         let mr_prime = Scalar::random(&mut self.rng);
@@ -78,22 +80,23 @@ where R: Rng {
         let m_id_bar_prime = G2::random(&mut self.rng);
         let m_sk = G2::random(&mut self.rng);
 
-
         let d_y = G1::one() * ms;
         let d_1 = G1::one() * mr;
-        let d_b_star = G1::one() * mb_star + statement.h1 * mr_star; 
+        let d_b_star = G1::one() * mb_star + statement.h1 * mr_star;
         let d_b_prime = G1::one() * mb_prime + statement.h1 * mr_prime;
 
         let r = pairing(statement.c1, m_id) * pairing(G1::one().neg(), m_id_prime);
         let r_bar = pairing(statement.c1, m_id_bar) * pairing(G1::one().neg(), m_id_bar_prime);
         let r_sk = pairing(statement.y, m_id) * pairing(G1::one().neg(), m_sk);
-        
+
         let gt = pairing(G1::one(), G2::one());
         let d_2 = gt.pow(mb_star) * pairing(statement.y, m_id_prime);
         let d_2_bar = gt.pow(mb_star) * pairing(statement.y_bar, m_id_bar_prime);
         let d_2_tilde = gt.pow(mb_prime) * pairing(statement.c1_tilde, m_sk);
-        
-        let script = d_y.to_bytes().iter()
+
+        let script = d_y
+            .to_bytes()
+            .iter()
             .chain(d_1.to_bytes().iter())
             .chain(d_b_star.to_bytes().iter())
             .chain(d_b_prime.to_bytes().iter())
@@ -102,8 +105,7 @@ where R: Rng {
             .chain(r_sk.to_bytes().iter())
             .chain(d_2.to_bytes().iter())
             .chain(d_2_bar.to_bytes().iter())
-            .chain(d_2_tilde.to_bytes().iter())
-            .map(|x| *x)
+            .chain(d_2_tilde.to_bytes().iter()).copied()
             .collect::<Vec<_>>();
         let x = hash_to_scalar(&script);
 
@@ -117,7 +119,7 @@ where R: Rng {
         let h_id_prime = witness.h_id * witness.r;
         let h_id_bar_prime = witness.h_id_bar * witness.r;
 
-        let z_id = witness.h_id * x + m_id; 
+        let z_id = witness.h_id * x + m_id;
         let z_id_prime = h_id_prime * x + m_id_prime;
         let z_id_bar = witness.h_id_bar * x + m_id_bar;
         let z_id_bar_prime = h_id_bar_prime * x + m_id_bar_prime;
@@ -140,32 +142,36 @@ where R: Rng {
     }
 }
 
-
 pub struct TransferVerifier;
 
 impl TransferVerifier {
     pub fn verify_proof(statement: TransferStatement, proof: TransferProof) -> Result<(), ZkError> {
         let d_y = G1::one() * proof.zs - statement.y * proof.x;
         let d_1 = G1::one() * proof.zr - statement.c1 * proof.x;
-        let d_b_star = G1::one() * proof.zb_star + statement.h1 * proof.zr_star - statement.c_b_star * proof.x;
-        let d_b_prime = G1::one() * proof.zb_prime + statement.h1 * proof.zr_prime - statement.c_b_prime * proof.x;
+        let d_b_star =
+            G1::one() * proof.zb_star + statement.h1 * proof.zr_star - statement.c_b_star * proof.x;
+        let d_b_prime = G1::one() * proof.zb_prime + statement.h1 * proof.zr_prime
+            - statement.c_b_prime * proof.x;
 
         let r = pairing(statement.c1, proof.z_id) * pairing(G1::one().neg(), proof.z_id_prime);
-        let r_bar = pairing(statement.c1, proof.z_id_bar) * pairing(G1::one().neg(), proof.z_id_bar_prime);
+        let r_bar =
+            pairing(statement.c1, proof.z_id_bar) * pairing(G1::one().neg(), proof.z_id_bar_prime);
         let r_sk = pairing(statement.y, proof.z_id) * pairing(G1::one().neg(), proof.z_sk);
 
         let gt = pairing(G1::one(), G2::one());
-        let d_2 = gt.pow(proof.zb_star) * 
-            pairing(statement.y, proof.z_id_prime) *
-            statement.c2.pow(proof.x).inverse().unwrap();
-        let d_2_bar = gt.pow(proof.zb_star) *
-            pairing(statement.y_bar, proof.z_id_bar_prime) *
-            statement.c2_bar.pow(proof.x).inverse().unwrap();
-        let d_2_tilde = gt.pow(proof.zb_prime) * 
-            pairing(statement.c1_tilde, proof.z_sk) *
-            statement.c2_tilde.pow(proof.x).inverse().unwrap();
+        let d_2 = gt.pow(proof.zb_star)
+            * pairing(statement.y, proof.z_id_prime)
+            * statement.c2.pow(proof.x).inverse().unwrap();
+        let d_2_bar = gt.pow(proof.zb_star)
+            * pairing(statement.y_bar, proof.z_id_bar_prime)
+            * statement.c2_bar.pow(proof.x).inverse().unwrap();
+        let d_2_tilde = gt.pow(proof.zb_prime)
+            * pairing(statement.c1_tilde, proof.z_sk)
+            * statement.c2_tilde.pow(proof.x).inverse().unwrap();
 
-        let script = d_y.to_bytes().iter()
+        let script = d_y
+            .to_bytes()
+            .iter()
             .chain(d_1.to_bytes().iter())
             .chain(d_b_star.to_bytes().iter())
             .chain(d_b_prime.to_bytes().iter())
@@ -174,17 +180,14 @@ impl TransferVerifier {
             .chain(r_sk.to_bytes().iter())
             .chain(d_2.to_bytes().iter())
             .chain(d_2_bar.to_bytes().iter())
-            .chain(d_2_tilde.to_bytes().iter())
-            .map(|x| *x)
+            .chain(d_2_tilde.to_bytes().iter()).copied()
             .collect::<Vec<_>>();
         let x = hash_to_scalar(&script);
 
         if x == proof.x {
             Ok(())
-        }
-        else {
+        } else {
             Err(ZkError::VerificationError)
         }
     }
 }
-

--- a/aibe/tests/test_bf_ibe.rs
+++ b/aibe/tests/test_bf_ibe.rs
@@ -1,15 +1,13 @@
-
-use aibe::traits::{IdentityBasedEncryption};
-use aibe::bf_ibe::{BFIbe};
-use aibe::utils::{u64_to_scalar};
+use aibe::bf_ibe::BFIbe;
+use aibe::traits::IdentityBasedEncryption;
+use aibe::utils::u64_to_scalar;
 use rand::Rng;
-
 
 #[test]
 fn test_bf_ibe() {
     use std::time::Instant;
 
-    let mut rng = rand::thread_rng(); 
+    let mut rng = rand::thread_rng();
     let bound: u64 = 100;
     let plain: u64 = rng.gen_range(0..bound);
 
@@ -33,12 +31,10 @@ fn test_bf_ibe() {
     println!("[IBE encrypt]: {:.2?}", elapsed);
 
     let now = Instant::now();
-    let result = ibe.decrypt(&cipher, "zico", &sk, bound); 
+    let result = ibe.decrypt(&cipher, "zico", &sk, bound);
     let elapsed = now.elapsed();
     println!("[IBE Decrypt]: {:.2?}", elapsed);
 
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), u64_to_scalar(plain));
 }
-
-

--- a/aibe/tests/test_zk_burn.rs
+++ b/aibe/tests/test_zk_burn.rs
@@ -1,16 +1,14 @@
-
-use aibe::traits::{IdentityBasedEncryption};
-use aibe::bf_ibe::{BFIbe};
-use aibe::utils::{u64_to_scalar, hash_to_g2};
-use aibe::zk::burn::{BurnStatement, BurnWitness, BurnProver, BurnVerifier};
+use aibe::bf_ibe::BFIbe;
+use aibe::traits::IdentityBasedEncryption;
+use aibe::utils::{hash_to_g2, u64_to_scalar};
+use aibe::zk::burn::{BurnProver, BurnStatement, BurnVerifier, BurnWitness};
 use rand::Rng;
-
 
 #[test]
 fn test_zk_burn() {
     use std::time::Instant;
 
-    let mut rng = rand::thread_rng(); 
+    let mut rng = rand::thread_rng();
     let bound: u64 = 100;
     let plain = u64_to_scalar(rng.gen_range(0..bound));
 
@@ -34,13 +32,12 @@ fn test_zk_burn() {
     println!("[IBE encrypt]: {:.2?}", elapsed);
 
     let now = Instant::now();
-    let result = ibe.decrypt(&cipher, "zico", &sk, bound); 
+    let result = ibe.decrypt(&cipher, "zico", &sk, bound);
     let elapsed = now.elapsed();
     println!("[IBE Decrypt]: {:.2?}", elapsed);
 
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), plain);
-
 
     let statement = BurnStatement {
         y: mpk,
@@ -60,5 +57,3 @@ fn test_zk_burn() {
     let result = BurnVerifier::verify_proof(statement, proof);
     assert!(result.is_ok());
 }
-
-

--- a/aibe/tests/test_zk_transfer.rs
+++ b/aibe/tests/test_zk_transfer.rs
@@ -1,18 +1,16 @@
-
-use aibe::traits::{IdentityBasedEncryption};
-use aibe::bf_ibe::{BFIbe};
-use aibe::utils::{u64_to_scalar, hash_to_g2, pedersen_commitment};
-use aibe::zk::transfer::{TransferStatement, TransferWitness, TransferProver, TransferVerifier};
-use rand::Rng;
-use bn::{G1, Group};
+use aibe::bf_ibe::BFIbe;
+use aibe::traits::IdentityBasedEncryption;
+use aibe::utils::{pedersen_commitment, u64_to_scalar};
+use aibe::zk::transfer::{TransferProver, TransferStatement, TransferVerifier, TransferWitness};
+use bn::{Group, G1};
 
 
 #[test]
 fn test_zk_transfer() {
     use std::time::Instant;
 
-    let mut rng = rand::thread_rng(); 
-    let bound: u64 = 100;
+    let mut rng = rand::thread_rng();
+    let _bound: u64 = 100;
     // Balance
     let b = u64_to_scalar(60);
     // Transfer amount
@@ -24,7 +22,7 @@ fn test_zk_transfer() {
 
     let now = Instant::now();
     let (msk1, mpk1) = ibe.generate_key();
-    let (msk2, mpk2) = ibe.generate_key();
+    let (_msk2, mpk2) = ibe.generate_key();
     let elapsed = now.elapsed();
     println!("[IBE key gen]: {:.2?}", elapsed);
 
@@ -37,15 +35,16 @@ fn test_zk_transfer() {
     // Encryption of balance for key 1
     let c_balance = ibe.encrypt(&b, "zico1", &mpk1);
     // Encryption of transfer amount for key 1 and key 2
-    let ((c_transfer, c_transfer_bar), (h_id, h_id_bar), r) = ibe.encrypt_correlated_internal(&b_star, ("zico1", "zico2"), (&mpk1, &mpk2));
+    let ((c_transfer, c_transfer_bar), (h_id, h_id_bar), r) =
+        ibe.encrypt_correlated_internal(&b_star, ("zico1", "zico2"), (&mpk1, &mpk2));
     let elapsed = now.elapsed();
     println!("[IBE encrypt]: {:.2?}", elapsed);
 
     let h1 = G1::random(&mut rng);
 
     let now = Instant::now();
-    let (r_star, c_b_star) = pedersen_commitment(b_star, h1, &mut rng); 
-    let (r_prime, c_b_prime) = pedersen_commitment(b_prime, h1, &mut rng); 
+    let (r_star, c_b_star) = pedersen_commitment(b_star, h1, &mut rng);
+    let (r_prime, c_b_prime) = pedersen_commitment(b_prime, h1, &mut rng);
     let elapsed = now.elapsed();
     println!("[Pedersen commitment]: {:.2?}", elapsed);
 
@@ -79,5 +78,3 @@ fn test_zk_transfer() {
     let result = TransferVerifier::verify_proof(statement, proof);
     assert!(result.is_ok());
 }
-
-


### PR DESCRIPTION
Hi - since we keep copies of milestone deliveries over at https://github.com/w3f-grants-archive, I've made some additional changes to the `aibe` directory:

* Running `cargo fmt` to fix some formatting issues (note that this changes the tabs used into spaces, which is more common. Most IDE's have the option to set your tab key to indent with e.g. 4 spaces instead of the tab character)
* Running `cargo clippy --fix` to fix some code smells
* Adding a `.gitignore` for lock files and build artifacts
* I also re-added the documentation changes from my previous PR since it looks like they were undone accidently by your previous commit